### PR TITLE
Fix loan payslip/input issues and modernize deprecated tracking for Odoo 18

### DIFF
--- a/ent_hr_custody/models/hr_custody.py
+++ b/ent_hr_custody/models/hr_custody.py
@@ -47,7 +47,7 @@ class HrCustody(models.Model):
                                         copy=False, readonly=1,
                                         help="Renew rejected reason")
     date_request = fields.Date(string='Requested Date', required=True,
-                               track_visibility='always', readonly=True,
+                               tracking=True, readonly=True,
                                help="Requested date",
                                states={'draft': [('readonly', False)]},
                                default=datetime.now().strftime('%Y-%m-%d'))
@@ -56,7 +56,7 @@ class HrCustody(models.Model):
                                default=lambda self: self.env.user.
                                employee_id.id,
                                states={'draft': [('readonly', False)]})
-    purpose = fields.Char(string='Reason', track_visibility='always',
+    purpose = fields.Char(string='Reason', tracking=True,
                           required=True, help="Reason")
     custody_name = fields.Many2one('custody.property', string='Property',
                                    required=True,
@@ -64,10 +64,10 @@ class HrCustody(models.Model):
     location = fields.Char(string="Location", readonly=True,
                            help="Source location of the product")
     return_date = fields.Date(string='Return Date', required=True,
-                              track_visibility='always',
+                              tracking=True,
                               help="Return date")
     renew_date = fields.Date(string='Renewal Return Date',
-                             track_visibility='always',
+                             tracking=True,
                              help="Return date for the renewal", readonly=True,
                              copy=False)
     notes = fields.Html(string='Notes', help="Internal Notes")
@@ -80,7 +80,7 @@ class HrCustody(models.Model):
          ('approved', 'Approved'),
          ('returned', 'Returned'), ('rejected', 'Refused')], string='Status',
         default='draft',
-        track_visibility='always', help="State in hr custody")
+        tracking=True, help="State in hr custody")
     mail_send = fields.Boolean(string="Mail Send", help="Is mail send or not")
     property_type = fields.Boolean(string="type", help="Property type")
 

--- a/ent_hr_disciplinary_tracking/models/disciplinary_action.py
+++ b/ent_hr_disciplinary_tracking/models/disciplinary_action.py
@@ -34,7 +34,7 @@ class DisciplinaryAction(models.Model):
         ('explain', 'Waiting Explanation'),
         ('submitted', 'Waiting Action'),
         ('action', 'Action Validated'),
-        ('cancel', 'Cancelled')], default='draft', track_visibility='onchange',
+        ('cancel', 'Cancelled')], default='draft', tracking=True,
         string="State",
         help="Disciplinary action record states")
     name = fields.Char(string='Reference', required=True, copy=False,

--- a/ent_hr_gratuity_settlement/models/hr_contract.py
+++ b/ent_hr_gratuity_settlement/models/hr_contract.py
@@ -34,13 +34,10 @@ class HRContract(models.Model):
     is_approve = fields.Boolean(string="Is Approve",
                                 help="Ensure the approval")
     state = fields.Selection(
-        selection=[
-            ('draft', 'New'),
-            ('probation', 'Probation'),
-            ('open', 'Running'),
-            ('close', 'Expired'),
-            ('cancel', 'Cancelled'),
-        ], string='Status', help="Ensure the record state"
+        selection_add=[('probation', 'Probation')],
+        ondelete={'probation': 'set default'},
+        string='Status',
+        help="Ensure the record state",
     )
     probation_id = fields.Many2one('hr.training',
                                    string="Probation",
@@ -60,7 +57,7 @@ class HRContract(models.Model):
                                   ('hourly', 'Hourly Wage')],
                                  string="Wage Type", help="Choose "
                                                           "wage type")
-    hourly_wage = fields.Monetary(string='Hourly Wage', digits=(16, 2),
+    hourly_wage = fields.Monetary(string='Hourly Wage',
                                   default=0, required=True, tracking=True,
                                   help="Employee's hourly gross wage.")
 

--- a/ent_hr_lawsuit_management/models/hr_lawsuit.py
+++ b/ent_hr_lawsuit_management/models/hr_lawsuit.py
@@ -72,14 +72,14 @@ class HrLawsuit(models.Model):
                                  help='Start Date')
     hearing_date = fields.Date(string='Hearing Date',
                                help='Upcoming hearing date')
-    court_name = fields.Char(string='Court Name', track_visibility='always',
+    court_name = fields.Char(string='Court Name', tracking=True,
                              states={'won': [('readonly', True)]},
                              help='Name of the Court')
-    judge = fields.Char(string='Judge', track_visibility='always',
+    judge = fields.Char(string='Judge', tracking=True,
                         states={'won': [('readonly', True)]},
                         help='Name of the Judge')
     lawyer_id = fields.Many2one('res.partner', string='Lawyer',
-                                track_visibility='always',
+                                tracking=True,
                                 help='Choose the contact of Layer from the '
                                      'contact list',
                                 states={'won': [('readonly', True)]})
@@ -105,13 +105,13 @@ class HrLawsuit(models.Model):
     party2_name = fields.Char(compute='_compute_party2_name', string='Name',
                               store=True, help="Name of the second party")
     case_details = fields.Html(string='Case Details', copy=False,
-                               track_visibility='always',
+                               tracking=True,
                                help='More details of the case')
     state = fields.Selection([('draft', 'Draft'),
                               ('running', 'Running'),
                               ('cancel', 'Cancelled'),
                               ('fail', 'Failed'),
                               ('won', 'Won')], string='Status',
-                             default='draft', track_visibility='always',
+                             default='draft', tracking=True,
                              copy=False,
                              help='Status')

--- a/ent_hr_resignation/models/hr_resignation.py
+++ b/ent_hr_resignation/models/hr_resignation.py
@@ -51,11 +51,11 @@ class HrResignation(models.Model):
     resign_confirm_date = fields.Date(string="Confirmed Date",
                                       help='Date on which the request is '
                                            'confirmed by the employee.',
-                                      track_visibility="always")
+                                      tracking=True)
     approved_revealing_date = fields.Date(
         string="Approved Last Day Of Employee",
         help='Date on which the request is confirmed by the manager.',
-        track_visibility="always")
+        tracking=True)
     joined_date = fields.Date(string="Join Date", store=True,
                               help='Joining date of the employee.i.e Start '
                                    'date of the first contract')
@@ -72,7 +72,7 @@ class HrResignation(models.Model):
         [('draft', 'Draft'), ('confirm', 'Confirm'),
          ('approved', 'Approved'),
          ('cancel', 'Rejected')],
-        string='Status', default='draft', track_visibility="always")
+        string='Status', default='draft', tracking=True)
     resignation_type = fields.Selection(selection=RESIGNATION_TYPE,
                                         string='Resignation Type',
                                         help="Select the type of "

--- a/ent_hr_reward_warning/models/hr_announcement.py
+++ b/ent_hr_reward_warning/models/hr_announcement.py
@@ -41,7 +41,7 @@ class HrAnnouncement(models.Model):
          ('approved', 'Approved'), ('rejected', 'Refused'),
          ('expired', 'Expired')],
         string='Status', default='draft',
-        track_visibility='always', help="State of the Announcement")
+        tracking=True, help="State of the Announcement")
     requested_date = fields.Date(string='Requested Date',
                                  default=datetime.now().strftime('%Y-%m-%d'),
                                  help="Create Date of Record")

--- a/ent_loan_accounting/models/hr_loan.py
+++ b/ent_loan_accounting/models/hr_loan.py
@@ -47,7 +47,7 @@ class HrLoan(models.Model):
         ('approve', 'Approved'),
         ('refuse', 'Refused'),
         ('cancel', 'Canceled'),
-    ], string="State", default='draft', track_visibility='onchange',
+    ], string="State", default='draft', tracking=True,
         copy=False)
 
     def action_approve(self):

--- a/ent_ohrms_loan/models/hr_loan.py
+++ b/ent_ohrms_loan/models/hr_loan.py
@@ -95,8 +95,8 @@ class HrLoan(models.Model):
 
     def _compute_loan_amount(self):
         """ calculate the total amount paid towards the loan. """
-        total_paid = 0.0
         for loan in self:
+            total_paid = 0.0
             for line in loan.loan_line_ids:
                 if line.paid:
                     total_paid += line.amount

--- a/ent_ohrms_loan/models/hr_payslip.py
+++ b/ent_ohrms_loan/models/hr_payslip.py
@@ -20,7 +20,7 @@
 #    USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 ################################################################################
-from odoo import models
+from odoo import Command, models
 
 
 class HrPayslip(models.Model):
@@ -51,7 +51,7 @@ class HrPayslip(models.Model):
                             if data.date_from <= line.date <= data.date_to:
                                 if not line.paid:
                                     amount = line.amount
-                                    name = loan_line.id
+                                    name = loan_line[:1].id
                                     data.input_data_line(name, amount, line)
         return super(HrPayslip, self).compute_sheet()
 
@@ -65,14 +65,21 @@ class HrPayslip(models.Model):
 
     def input_data_line(self, name, amount, loan):
         """Add loan details to payslip as other input"""
-        check_lines = []
-        new_name = self.env['hr.payslip.input.type'].search([
-            ('input_id', '=', name)])
-        line = (0, 0, {
-            'input_type_id': new_name.id,
-            'amount': amount,
-            'name': 'LO',
-            'loan_line_id': loan.id
+        input_type = self.env['hr.payslip.input.type'].search(
+            [('input_id', '=', name)],
+            limit=1,
+        )
+        if not input_type:
+            input_type = self.env['hr.payslip.input.type'].create({
+                'name': 'Loan',
+                'code': 'LO',
+                'input_id': name,
+            })
+        self.write({
+            'input_line_ids': [Command.create({
+                'input_type_id': input_type.id,
+                'amount': amount,
+                'name': 'LO',
+                'loan_line_id': loan.id,
+            })],
         })
-        check_lines.append(line)
-        self.input_line_ids = check_lines

--- a/ent_saudi_gosi/models/gosi_payslip.py
+++ b/ent_saudi_gosi/models/gosi_payslip.py
@@ -38,15 +38,15 @@ class GosiPayslip(models.Model):
     nationality = fields.Char(string='Nationality', required=True,
                               help="Employee nationality")
     type_gosi = fields.Char(string='Type', required=True,
-                            track_visibility='onchange',
+                            tracking=True,
                             help="Choose a gosi type")
     dob = fields.Char(string='Date Of Birth', required=True,
                       help="Enter Date of Birth")
     gos_numb = fields.Char(string='GOSI Number', required=True,
-                           track_visibility='onchange',
+                           tracking=True,
                            help="Enter Gosi number")
     issued_dat = fields.Char(string='Issued Date', required=True,
-                             track_visibility='onchange',
+                             tracking=True,
                              help="Issued date")
     name = fields.Char(string='Reference', required=True, copy=False,
                        readonly=True,


### PR DESCRIPTION
### Motivation
- Close several open issues related to loan payroll and migration warnings by making the loan input generation robust and removing deprecated field attributes for Odoo 18 compatibility. 
- Ensure payslip loan inputs are appended (not overwritten) and prevent missing `hr.payslip.input.type` errors when multiple salary structures are used. 
- Remove deprecated `track_visibility` and other migration regressions reported during upgrade checks. 

### Description
- In `ent_ohrms_loan/models/hr_payslip.py` changed the loan salary-rule lookup to use a single `LO` rule (`loan_line[:1].id`), switched to `Command.create` for appending `input_line_ids`, and added a fallback creation of `hr.payslip.input.type` when none exists. 
- In `ent_ohrms_loan/models/hr_loan.py` reset the `total_paid` accumulator per loan record to avoid cross-record accumulation during `_compute_loan_amount`. 
- In `ent_hr_gratuity_settlement/models/hr_contract.py` migrated the `state` field to use `selection_add` and `ondelete` instead of overriding the whole selection, and removed the deprecated `digits` parameter from the `Monetary` field. 
- Replaced deprecated `track_visibility` usages with `tracking=True` across modules to align with Odoo 18 (files changed include `ent_hr_custody`, `ent_hr_disciplinary_tracking`, `ent_hr_lawsuit_management`, `ent_hr_resignation`, `ent_hr_reward_warning`, `ent_loan_accounting`, `ent_saudi_gosi`). 

### Testing
- Ran `python -m compileall` over modified modules (`ent_ohrms_loan`, `ent_hr_gratuity_settlement`, `ent_hr_lawsuit_management`, `ent_hr_resignation`, `ent_hr_reward_warning`, `ent_hr_custody`, `ent_hr_disciplinary_tracking`, `ent_saudi_gosi`, `ent_loan_accounting`) and compilation completed successfully. 
- Searched for deprecated tokens with ripgrep (`rg -n

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65c1473488328b7175dd053c1b7f4)