### PR TITLE
[FIX] Odoo 17 compatibility: batch-create and selection/visibility updates for loans and advances

### DIFF
--- a/ent_loan_accounting/models/hr_loan.py
+++ b/ent_loan_accounting/models/hr_loan.py
@@ -40,15 +40,14 @@ class HrLoan(models.Model):
     journal_id = fields.Many2one(comodel_name='account.journal',
                                  string="Journal",
                                  help="Select journal for employee")
-    state = fields.Selection([
-        ('draft', 'Draft'),
-        ('waiting_approval_1', 'Submitted'),
-        ('waiting_approval_2', 'Waiting Approval'),
-        ('approve', 'Approved'),
-        ('refuse', 'Refused'),
-        ('cancel', 'Canceled'),
-    ], string="State", default='draft', track_visibility='onchange',
-        copy=False)
+    state = fields.Selection(
+        selection_add=[('waiting_approval_2', 'Waiting Approval')],
+        ondelete={'waiting_approval_2': 'set default'},
+        string="State",
+        default='draft',
+        tracking=True,
+        copy=False,
+    )
 
     def action_approve(self):
         """ This creates an invoice in account.move with loan request details.

--- a/ent_ohrms_loan/models/hr_loan.py
+++ b/ent_ohrms_loan/models/hr_loan.py
@@ -104,20 +104,23 @@ class HrLoan(models.Model):
     ], string="State", help="states of loan request", default='draft',
         tracking=True, copy=False, )
 
-    @api.model
-    def create(self, values):
-        """creates a new HR loan record with the provided values."""
-        loan_count = self.env['hr.loan'].search_count(
-            [('employee_id', '=', values['employee_id']),
-             ('state', '=', 'approve'),
-             ('balance_amount', '!=', 0)])
-        if loan_count:
-            raise ValidationError(
-                _("The employee has already a pending installment"))
-        else:
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Create loan records in batch-safe mode."""
+        for values in vals_list:
+            employee_id = values.get('employee_id')
+            if employee_id:
+                loan_count = self.env['hr.loan'].search_count([
+                    ('employee_id', '=', employee_id),
+                    ('state', '=', 'approve'),
+                    ('balance_amount', '!=', 0),
+                ])
+                if loan_count:
+                    raise ValidationError(
+                        _("The employee has already a pending installment")
+                    )
             values['name'] = self.env['ir.sequence'].get('hr.loan.seq') or ' '
-            res = super(HrLoan, self).create(values)
-            return res
+        return super(HrLoan, self).create(vals_list)
 
     def action_compute_installment(self):
         """This automatically create the installment the employee need to pay

--- a/ent_ohrms_salary_advance/models/salary_advance.py
+++ b/ent_ohrms_salary_advance/models/salary_advance.py
@@ -109,12 +109,12 @@ class SalaryAdvance(models.Model):
         """ Reject action for the advance salary request. """
         self.state = 'reject'
 
-    @api.model
-    def create(self, vals):
-        """ inheriting create method for adding sequence for the request. """
-        vals['name'] = self.env['ir.sequence'].get('salary.advance.seq') or ' '
-        res_id = super(SalaryAdvance, self).create(vals)
-        return res_id
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Inherit create for adding sequence values in batch mode."""
+        for vals in vals_list:
+            vals['name'] = self.env['ir.sequence'].get('salary.advance.seq') or ' '
+        return super(SalaryAdvance, self).create(vals_list)
 
     def approve_request(self):
         """ This Approves the employee salary advance request. """


### PR DESCRIPTION
### Motivation
- Fix Odoo 17 warnings about `create` not supporting batch creation and deprecated field parameters when loading HR/loan modules.
- Ensure state extension uses `selection_add` instead of overriding the entire selection to avoid selection conflicts.
- Replace deprecated `track_visibility` usage with the Odoo 17-compatible `tracking` parameter.

### Description
- Converted `create` in `ent_ohrms_loan/models/hr_loan.py` to `@api.model_create_multi` and updated validation/sequence assignment to handle `vals_list` safely per record.
- Converted `create` in `ent_ohrms_salary_advance/models/salary_advance.py` to `@api.model_create_multi` and assigned the sequence value for each record in the incoming list.
- Replaced the full `state` selection override in `ent_loan_accounting/models/hr_loan.py` with `selection_add=[('waiting_approval_2', 'Waiting Approval')]`, added `ondelete` handling, and changed `track_visibility` to `tracking=True`.

### Testing
- Ran `python -m compileall ent_ohrms_loan/models/hr_loan.py ent_ohrms_salary_advance/models/salary_advance.py ent_loan_accounting/models/hr_loan.py`, which completed successfully.
- Searched the repository for the failing registry model `hr.leave.allocation.generate.multi.wizard` and confirmed it is not present in this repository, indicating the remaining registry error originates from an external addon.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7e3f42788328950297e4bd241de1)