### PR TITLE
Make create methods bulk-safe, add leave-allocation wizard alias, and adjust loan state field

### DIFF
--- a/ent_hr_holidays_approval/models/__init__.py
+++ b/ent_hr_holidays_approval/models/__init__.py
@@ -21,3 +21,5 @@
 ########################################################################################
 from . import hr_leave
 from . import hr_leave_type
+
+from . import hr_leave_allocation_generate_multi_wizard

--- a/ent_hr_holidays_approval/models/hr_leave_allocation_generate_multi_wizard.py
+++ b/ent_hr_holidays_approval/models/hr_leave_allocation_generate_multi_wizard.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+######################################################################################
+#
+#    A part of Open HRMS Project <https://www.openhrms.com>
+#
+#    Copyright (C) 2024-TODAY Cybrosys Technologies(<https://www.cybrosys.com>).
+#    Author: Cybrosys Techno Solutions (odoo@cybrosys.com)
+#
+#    This program is under the terms of the Odoo Proprietary License v1.0 (OPL-1)
+#
+########################################################################################
+from odoo import models
+
+
+class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
+    """Compatibility alias for Odoo 17 wizard model rename.
+
+    Some localization addons still inherit `hr.leave.allocation.generate.multi.wizard`
+    from older Odoo versions. In Odoo 17, the base model is
+    `hr.leave.allocation.generate.multi`.
+    """
+
+    _name = 'hr.leave.allocation.generate.multi.wizard'
+    _inherit = 'hr.leave.allocation.generate.multi'

--- a/ent_loan_accounting/models/hr_loan.py
+++ b/ent_loan_accounting/models/hr_loan.py
@@ -40,15 +40,14 @@ class HrLoan(models.Model):
     journal_id = fields.Many2one(comodel_name='account.journal',
                                  string="Journal",
                                  help="Select journal for employee")
-    state = fields.Selection([
-        ('draft', 'Draft'),
-        ('waiting_approval_1', 'Submitted'),
-        ('waiting_approval_2', 'Waiting Approval'),
-        ('approve', 'Approved'),
-        ('refuse', 'Refused'),
-        ('cancel', 'Canceled'),
-    ], string="State", default='draft', track_visibility='onchange',
-        copy=False)
+    state = fields.Selection(
+        selection_add=[('waiting_approval_2', 'Waiting Approval')],
+        ondelete={'waiting_approval_2': 'set default'},
+        string="State",
+        default='draft',
+        tracking=True,
+        copy=False,
+    )
 
     def action_approve(self):
         """ This creates an invoice in account.move with loan request details.

--- a/ent_ohrms_loan/models/hr_loan.py
+++ b/ent_ohrms_loan/models/hr_loan.py
@@ -104,20 +104,23 @@ class HrLoan(models.Model):
     ], string="State", help="states of loan request", default='draft',
         tracking=True, copy=False, )
 
-    @api.model
-    def create(self, values):
-        """creates a new HR loan record with the provided values."""
-        loan_count = self.env['hr.loan'].search_count(
-            [('employee_id', '=', values['employee_id']),
-             ('state', '=', 'approve'),
-             ('balance_amount', '!=', 0)])
-        if loan_count:
-            raise ValidationError(
-                _("The employee has already a pending installment"))
-        else:
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Create loan records in batch-safe mode."""
+        for values in vals_list:
+            employee_id = values.get('employee_id')
+            if employee_id:
+                loan_count = self.env['hr.loan'].search_count([
+                    ('employee_id', '=', employee_id),
+                    ('state', '=', 'approve'),
+                    ('balance_amount', '!=', 0),
+                ])
+                if loan_count:
+                    raise ValidationError(
+                        _("The employee has already a pending installment")
+                    )
             values['name'] = self.env['ir.sequence'].get('hr.loan.seq') or ' '
-            res = super(HrLoan, self).create(values)
-            return res
+        return super(HrLoan, self).create(vals_list)
 
     def action_compute_installment(self):
         """This automatically create the installment the employee need to pay

--- a/ent_ohrms_salary_advance/models/salary_advance.py
+++ b/ent_ohrms_salary_advance/models/salary_advance.py
@@ -109,12 +109,12 @@ class SalaryAdvance(models.Model):
         """ Reject action for the advance salary request. """
         self.state = 'reject'
 
-    @api.model
-    def create(self, vals):
-        """ inheriting create method for adding sequence for the request. """
-        vals['name'] = self.env['ir.sequence'].get('salary.advance.seq') or ' '
-        res_id = super(SalaryAdvance, self).create(vals)
-        return res_id
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Inherit create for adding sequence values in batch mode."""
+        for vals in vals_list:
+            vals['name'] = self.env['ir.sequence'].get('salary.advance.seq') or ' '
+        return super(SalaryAdvance, self).create(vals_list)
 
     def approve_request(self):
         """ This Approves the employee salary advance request. """


### PR DESCRIPTION
### Motivation
- Ensure record creation is safe when called with multiple records and preserve behavior when modules call `create` with lists. 
- Provide a compatibility alias for the renamed leave-allocation wizard to support localization modules that still reference the old model. 
- Avoid overriding existing loan state choices introduced elsewhere by using `selection_add` and ensure proper deletion behavior and tracking.

### Description
- Added `hr_leave_allocation_generate_multi_wizard` transient model that aliases `hr.leave.allocation.generate.multi.wizard` to `hr.leave.allocation.generate.multi` for compatibility. 
- Imported the new wizard module in `ent_hr_holidays_approval/models/__init__.py`. 
- Replaced full `state` selection in `ent_loan_accounting.models.hr_loan` with `selection_add=[('waiting_approval_2', 'Waiting Approval')]`, added `ondelete` handling, and enabled `tracking`. 
- Converted `create` in `ent_ohrms_loan.models.hr_loan` to `@api.model_create_multi`, iterating `vals_list` to validate pending approved loans per employee and assign `name` via sequence before delegating to `super`. 
- Converted `create` in `ent_ohrms_salary_advance.models.salary_advance` to `@api.model_create_multi` and assign sequence `name` for each set of values before calling `super`.

### Testing
- Ran ORM/CRUD smoke tests including bulk creation of `hr.loan` and `salary.advance` records and single-record creation flows, which succeeded. 
- Verified validation that prevents creating a new approved loan for an employee with a pending balance in bulk and single creates, which raised the expected `ValidationError` when applicable. 
- Imported modules and exercised the leave-allocation wizard alias to ensure no import errors, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7e3f42788328950297e4bd241de1)